### PR TITLE
fixes unit issues when difftime is allowed to auto-pick time units.

### DIFF
--- a/R/Hydrovol.R
+++ b/R/Hydrovol.R
@@ -54,7 +54,7 @@ Hydrovol <- function(dfQ, Q="Q", time="pdate", df.dates, bdate="bpdate",edate="e
       time1 <- subdfQ[1,time]
       time2 <- subdfQ[2,time]
       stime <- df.dates[i,bdate]
-      qest <- (Q2-Q1)*(as.numeric(difftime(stime,time1)))/(as.numeric(difftime(time2,time1)))+Q1
+      qest <- (Q2-Q1)*(as.numeric(difftime(stime,time1, units = 'mins')))/(as.numeric(difftime(time2,time1, units = 'mins')))+Q1
       
       subdfQ[1,Q] <- qest
       subdfQ[1,time] <- df.dates[i,bdate]
@@ -67,7 +67,7 @@ Hydrovol <- function(dfQ, Q="Q", time="pdate", df.dates, bdate="bpdate",edate="e
       time1 <- subdfQ[(sub.rows-1),time]
       time2 <- subdfQ[sub.rows,time]
       stime <- df.dates[i,edate]
-      qest <- (Q2-Q1)*(as.numeric(difftime(stime,time1)))/(as.numeric(difftime(time2,time1)))+Q1
+      qest <- (Q2-Q1)*(as.numeric(difftime(stime,time1, units = 'mins')))/(as.numeric(difftime(time2,time1, units = 'mins')))+Q1
       
       subdfQ[sub.rows,Q] <- qest
       subdfQ[sub.rows,time] <- df.dates[i,edate]


### PR DESCRIPTION
Need to define units in `difftime` otherwise will auto-choose. This was causing an issue when the difftime of an event start time and the last "punch" were close (e.g., minutes) but the time between punches was far (e.g., an hour). The `as.numeric` was then causing scaling issues. 